### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,6 @@
 #
 # Params class
 #
-class maven::params {
+class maven::params (
   $wget_url = 'http://www.bizdirusa.com/mirrors/apache/maven/maven-3'
-}
+){}


### PR DESCRIPTION
Permit changing URL to use other mirrors (actual mirror down!)
Usage:

---

class {  'maven::params':
    wget_url => 'http://apache.rediris.es/maven/maven-3',
## }
