### PR TITLE
wget_url referenced uninitialized self.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class maven (
   $install_from_package = false,
   $package              = undef,
   $package_ensure       = 'present',
-  $wget_url             = $wget_url,
+  $wget_url             = $maven::params::wget_url,
 ) inherits ::maven::params {
 
   anchor { '::maven::begin': } ->


### PR DESCRIPTION
In the previous version, the wget_url referenced itself before even being initialized instead of referencing the value in maven::params. I've changed the value for your review.